### PR TITLE
change timestamp to UTC instead of local time

### DIFF
--- a/senddata.py
+++ b/senddata.py
@@ -126,7 +126,7 @@ try:
             temp = sensor.data.temperature
             press = sensor.data.pressure
 
-            iso = time.ctime()
+            iso = time.asctime(time.gmtime())
 
             if enable_gas:
 


### PR DESCRIPTION
The InfluxDB API always assumes the timestamp to be UTC.
Setting the timestamp to local time can lead to some bad hiccups.

Especially leads to problems with Grafana not displaying the timestamps correctly.