### PR TITLE
Update senddata.py - initialize BME680 via I2C addresses

### DIFF
--- a/senddata.py
+++ b/senddata.py
@@ -53,7 +53,11 @@ except ValueError:
     print("ValueError parsing config.ini file. Check number datatypes!")
     sys.exit()
 
-sensor = bme680.BME680()
+try:
+    sensor = bme680.BME680(bme680.I2C_ADDR_PRIMARY)
+except IOError:
+    sensor = bme680.BME680(bme680.I2C_ADDR_SECONDARY)
+    
 raspid = get_raspid()
 
 now = datetime.datetime.now()


### PR DESCRIPTION
Avoid following error:

Traceback (most recent call last):
  File "senddata.py", line 56, in <module>
    sensor = bme680.BME680()
  File "/usr/lib/python3/dist-packages/bme680/__init__.py", line 25, in __init__
    self.chip_id = self._get_regs(CHIP_ID_ADDR, 1)
  File "/usr/lib/python3/dist-packages/bme680/__init__.py", line 296, in _get_regs
    return self._i2c.read_byte_data(self.i2c_addr, register)